### PR TITLE
Fix StringInt64Map marshaling issue

### DIFF
--- a/types/map.go
+++ b/types/map.go
@@ -16,7 +16,7 @@ type StringInt64Map map[string]int64
 }*/
 
 func (m StringInt64Map) MarshalJSON() ([]byte, error) {
-	xs := make([]interface{}, len(m))
+	xs := make([]interface{}, 0, len(m))
 	for k, v := range m {
 		xs = append(xs, []interface{}{k, v})
 	}


### PR DESCRIPTION
This fixes issue with marshaling of `types.StringInt64Map` type.

When marshaling `StringInt64Map` type, the resulting json structure has double the size of original map, e.g.:
```go
types.StringInt64Map{"key1":"value1", "key2":"value2", "key3":"value3"}
```
should be marshalled into:

```json
[["key1","value1"], ["key2","value2"], ["key3","value3"]]
```
but marshals into:

```json
[null, null, null, ["key1","value1"], ["key2","value2"], ["key3","value3"]]
```

this results in error on node side:
```
call failed: jsonrpc2: code 1 message: 7 bad_cast_exception: Bad Cast
Invalid cast from null_type to Array
    {"type":"null_type"}
th_a variant.cpp:537 get_array
```
Golos node vesion `0.16.4`