### PR TITLE
Add account_create serialization

### DIFF
--- a/encoding/transaction/encoder.go
+++ b/encoding/transaction/encoder.go
@@ -91,14 +91,14 @@ func (encoder *Encoder) Encode(v interface{}) error {
 		return encoder.EncodeNumber(v)
 
 	case string:
-		return encoder.encodeString(v)
 
+		return encoder.EncodeString(v)
 	default:
 		return errors.Errorf("encoder: unsupported type encountered")
 	}
 }
 
-func (encoder *Encoder) encodeString(v string) error {
+func (encoder *Encoder) EncodeString(v string) error {
 	if err := encoder.EncodeUVarint(uint64(len(v))); err != nil {
 		return errors.Wrapf(err, "encoder: failed to write string: %v", v)
 	}

--- a/encoding/transaction/encoder_rolling.go
+++ b/encoding/transaction/encoder_rolling.go
@@ -39,6 +39,12 @@ func (encoder *RollingEncoder) EncodeMoney(v string) {
 	}
 }
 
+func (encoder *RollingEncoder) EncodeString(v string) {
+	if encoder.err == nil {
+		encoder.err = encoder.next.EncodeString(v)
+	}
+}
+
 func (encoder *RollingEncoder) EncodePubKey(v string) {
 	if encoder.err == nil {
 		encoder.err = encoder.next.EncodePubKey(v)

--- a/transactions/signed_transaction.go
+++ b/transactions/signed_transaction.go
@@ -74,7 +74,10 @@ func (tx *SignedTransaction) Sign(privKeys [][]byte, chain *Chain) error {
 	chainid, _ := hex.DecodeString(chain.ID)
 	//fmt.Println(tx.Operations[0])
 	//fmt.Println(" ")
-	tx_raw, _ := tx.Serialize()
+	tx_raw, err := tx.Serialize()
+	if err != nil {
+		return err
+	}
 	//fmt.Println(tx_raw)
 	//fmt.Println(" ")
 	buf.Write(chainid)

--- a/types/operation_encode.go
+++ b/types/operation_encode.go
@@ -106,6 +106,25 @@ func (op *ConvertOperation) MarshalTransaction(encoder *transaction.Encoder) err
 }
 
 // encode AccountCreateOperation{}
+func (op *AccountCreateOperation) MarshalTransaction(encoder *transaction.Encoder) error {
+	enc := transaction.NewRollingEncoder(encoder)
+
+	enc.EncodeUVarint(uint64(TypeAccountCreate.Code()))
+
+	enc.EncodeMoney(op.Fee)
+	enc.EncodeString(op.Creator)
+	enc.EncodeString(op.NewAccountName)
+
+	enc.Encode(op.Owner)
+	enc.Encode(op.Active)
+	enc.Encode(op.Posting)
+
+	enc.EncodePubKey(op.MemoKey)
+	enc.EncodeString(op.JsonMetadata)
+
+	return enc.Err()
+}
+
 // encode AccountUpdateOperation{}
 // encode WitnessUpdateOperation{}
 func (op *WitnessUpdateOperation) MarshalTransaction(encoder *transaction.Encoder) error {
@@ -237,6 +256,27 @@ func (op *DeclineVotingRightsOperation) MarshalTransaction(encoder *transaction.
 	enc.EncodeUVarint(uint64(TypeDeclineVotingRights.Code()))
 	enc.Encode(op.Account)
 	enc.EncodeBool(op.Decline)
+	return enc.Err()
+}
+
+func (auth *Authority) MarshalTransaction(encoder *transaction.Encoder) error {
+	enc := transaction.NewRollingEncoder(encoder)
+	enc.EncodeNumber(uint32(auth.WeightThreshold))
+
+	// encode AccountAuths as map[string]uint16
+	enc.EncodeUVarint(uint64(len(auth.AccountAuths)))
+	for k, v := range auth.AccountAuths {
+		enc.EncodeString(k)
+		enc.EncodeNumber(uint16(v))
+	}
+
+	// encode KeyAuths as map[PubKey]uint16
+	enc.EncodeUVarint(uint64(len(auth.KeyAuths)))
+	for k, v := range auth.KeyAuths {
+		enc.EncodePubKey(k)
+		enc.EncodeNumber(uint16(v))
+	}
+
 	return enc.Err()
 }
 


### PR DESCRIPTION
Add support for account_create operation

This adds serialization for `AccountCreateOperation` & `Authority` structs
Helper function to be done

Rename `Encoder.encodeString()` to `Encoder.EncodeString()` for usage in `RollingEncoder` & `MarshalTransaction` implementations

Remove error suppression in `SignedTransaction.Sign()` bacause:
1.  It's wrong
1. Combined with the lack of documentation and/or code comments it's VERY confusing